### PR TITLE
Updating to lastest Swagger-Promote version 1.6.7-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.github.axway-api-management-plus.swagger-promote</groupId>
             <artifactId>axway-swagger-promote-core</artifactId>
-            <version>1.6.6-1</version>
+            <version>1.6.7-1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This version is fixing an issue with V-Hosts causing an exception. See https://github.com/Axway-API-Management-Plus/apimanager-swagger-promote/issues/282